### PR TITLE
Add Archive management

### DIFF
--- a/ipa/scripts/cli.py
+++ b/ipa/scripts/cli.py
@@ -28,8 +28,6 @@ import tempfile
 
 import click
 
-from datetime import datetime
-
 from ipa.ipa_constants import (
     IPA_HISTORY_FILE,
     SUPPORTED_DISTROS,
@@ -346,14 +344,19 @@ def results(context, history_log):
     'path',
     type=click.Path(exists=True),
 )
+@click.argument(
+    'name',
+    type=click.STRING
+)
 @click.pass_context
-def archive(context, clear_log, items, path):
+def archive(context, clear_log, items, path, name):
     """
     Archive the history log and all results/log files.
 
     After archive is created optionally clear the history log.
     """
     history_log = context.obj['history_log']
+    no_color = context.obj['no_color']
 
     with open(history_log, 'r') as f:
         # Get history items
@@ -372,10 +375,9 @@ def archive(context, clear_log, items, path):
         for item in history_items:
             # Copy log and results file,
             # update results file with relative path.
-            archive_history_item(item, temp_dir)
+            archive_history_item(item, temp_dir, no_color)
 
-        time_stamp = datetime.now().strftime('%Y%m%d%H%M%S')
-        file_name = ''.join(['ipa_', time_stamp, '.tar.gz'])
+        file_name = ''.join([name, '.tar.gz'])
         archive_path = os.path.join(path, file_name)
 
         with tarfile.open(archive_path, "w:gz") as tar:

--- a/ipa/scripts/cli_utils.py
+++ b/ipa/scripts/cli_utils.py
@@ -31,7 +31,7 @@ from ipa.ipa_controller import collect_results
 from ipa.ipa_utils import parse_test_name, update_history_log
 
 
-def archive_history_item(item, destination):
+def archive_history_item(item, destination, no_color):
     """
     Archive the log and results file for the given history item.
 
@@ -47,18 +47,23 @@ def archive_history_item(item, destination):
     results_src = log_src.rsplit('.', 1)[0] + '.results'
     results_dest = log_dest.rsplit('.', 1)[0] + '.results'
 
-    try:
-        destination_path = os.path.join(destination, log_dest)
+    destination_path = os.path.join(destination, log_dest)
+    log_dir = os.path.dirname(destination_path)
 
-        log_dir = os.path.dirname(destination_path)
+    try:
         if not os.path.isdir(log_dir):
             os.makedirs(log_dir)
 
         # Copy results and log files to archive directory.
         shutil.copyfile(log_src, destination_path)
         shutil.copyfile(results_src, os.path.join(destination, results_dest))
-    except Exception:
-        pass  # File does not exist, nothing we can do now.
+    except Exception as error:
+        echo_style(
+            'Unable to archive history item: %s' % error,
+            no_color,
+            fg='red'
+        )
+        sys.exit(1)
     else:
         # Only update the archive results log if no error occur.
         update_history_log(

--- a/ipa/scripts/cli_utils.py
+++ b/ipa/scripts/cli_utils.py
@@ -20,13 +20,52 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import shlex
+import shutil
 import sys
 
 import click
 
 from ipa.ipa_controller import collect_results
-from ipa.ipa_utils import parse_test_name
+from ipa.ipa_utils import parse_test_name, update_history_log
+
+
+def archive_history_item(item, destination):
+    """
+    Archive the log and results file for the given history item.
+
+    Copy the files and update the results file in destination directory.
+    """
+    log_src, description = split_history_item(item.strip())
+
+    # Get relative path for log:
+    # {provider}/{image}/{instance}/{timestamp}.log
+    log_dest = os.path.sep.join(log_src.rsplit(os.path.sep, 4)[1:])
+
+    # Get results src and destination based on log paths.
+    results_src = log_src.rsplit('.', 1)[0] + '.results'
+    results_dest = log_dest.rsplit('.', 1)[0] + '.results'
+
+    try:
+        destination_path = os.path.join(destination, log_dest)
+
+        log_dir = os.path.dirname(destination_path)
+        if not os.path.isdir(log_dir):
+            os.makedirs(log_dir)
+
+        # Copy results and log files to archive directory.
+        shutil.copyfile(log_src, destination_path)
+        shutil.copyfile(results_src, os.path.join(destination, results_dest))
+    except Exception:
+        pass  # File does not exist, nothing we can do now.
+    else:
+        # Only update the archive results log if no error occur.
+        update_history_log(
+            os.path.join(destination, '.history'),
+            description=description,
+            test_log=log_dest
+        )
 
 
 def echo_log(log_file, no_color):
@@ -161,3 +200,16 @@ def results_history(history_log, no_color):
     for item in lines:
         click.echo('{} {}'.format(index, item), nl=False)
         index -= 1
+
+
+def split_history_item(history):
+    """
+    Return the log file and optional description for item.
+    """
+    try:
+        log_file, description = shlex.split(history)
+    except ValueError:
+        log_file = history.strip()
+        description = None
+
+    return log_file, description

--- a/man/man1/ipa-list.1
+++ b/man/man1/ipa-list.1
@@ -1,4 +1,4 @@
-.TH "IPA LIST" "1" "20-Jun-2018" "" "ipa list Manual"
+.TH "IPA LIST" "1" "21-Jun-2018" "" "ipa list Manual"
 .SH NAME
 ipa\-list \- Print a list of test files or test cases.
 .SH SYNOPSIS

--- a/man/man1/ipa-results-archive.1
+++ b/man/man1/ipa-results-archive.1
@@ -1,0 +1,17 @@
+.TH "IPA RESULTS ARCHIVE" "1" "21-Jun-2018" "" "ipa results archive Manual"
+.SH NAME
+ipa\-results\-archive \- Archive the history log and all results/log...
+.SH SYNOPSIS
+.B ipa results archive
+[OPTIONS] PATH NAME
+.SH DESCRIPTION
+Archive the history log and all results/log files.
+.PP
+After archive is created optionally clear the history log.
+.SH OPTIONS
+.TP
+\fB\-c,\fP \-\-clear\-log
+Clear the history log after archiving.
+.TP
+\fB\-i,\fP \-\-items TEXT
+List of history items to archive. Must be a comma separated list.

--- a/man/man1/ipa-results-clear.1
+++ b/man/man1/ipa-results-clear.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS CLEAR" "1" "20-Jun-2018" "" "ipa results clear Manual"
+.TH "IPA RESULTS CLEAR" "1" "21-Jun-2018" "" "ipa results clear Manual"
 .SH NAME
 ipa\-results\-clear \- Clear the results from the history file.
 .SH SYNOPSIS

--- a/man/man1/ipa-results-delete.1
+++ b/man/man1/ipa-results-delete.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS DELETE" "1" "20-Jun-2018" "" "ipa results delete Manual"
+.TH "IPA RESULTS DELETE" "1" "21-Jun-2018" "" "ipa results delete Manual"
 .SH NAME
 ipa\-results\-delete \- Delete the specified history item from the...
 .SH SYNOPSIS

--- a/man/man1/ipa-results-list.1
+++ b/man/man1/ipa-results-list.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS LIST" "1" "20-Jun-2018" "" "ipa results list Manual"
+.TH "IPA RESULTS LIST" "1" "21-Jun-2018" "" "ipa results list Manual"
 .SH NAME
 ipa\-results\-list \- Display list of results history.
 .SH SYNOPSIS

--- a/man/man1/ipa-results-show.1
+++ b/man/man1/ipa-results-show.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS SHOW" "1" "20-Jun-2018" "" "ipa results show Manual"
+.TH "IPA RESULTS SHOW" "1" "21-Jun-2018" "" "ipa results show Manual"
 .SH NAME
 ipa\-results\-show \- Print test results info from provided results...
 .SH SYNOPSIS

--- a/man/man1/ipa-results.1
+++ b/man/man1/ipa-results.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS" "1" "20-Jun-2018" "" "ipa results Manual"
+.TH "IPA RESULTS" "1" "21-Jun-2018" "" "ipa results Manual"
 .SH NAME
 ipa\-results \- Process provided history log and results...
 .SH SYNOPSIS
@@ -11,6 +11,10 @@ Process provided history log and results files.
 \fB\-\-history\-log\fP PATH
 Location of the history log file to display results from.
 .SH COMMANDS
+.PP
+\fBarchive\fP
+  Archive the history log and all results/log...
+  See \fBipa results-archive(1)\fP for full documentation on the \fBarchive\fP command.
 .PP
 \fBclear\fP
   Clear the results from the history file.

--- a/man/man1/ipa-test.1
+++ b/man/man1/ipa-test.1
@@ -1,4 +1,4 @@
-.TH "IPA TEST" "1" "20-Jun-2018" "" "ipa test Manual"
+.TH "IPA TEST" "1" "21-Jun-2018" "" "ipa test Manual"
 .SH NAME
 ipa\-test \- Test image in the given framework using the...
 .SH SYNOPSIS

--- a/man/man1/ipa.1
+++ b/man/man1/ipa.1
@@ -1,4 +1,4 @@
-.TH "IPA" "1" "20-Jun-2018" "" "ipa Manual"
+.TH "IPA" "1" "21-Jun-2018" "" "ipa Manual"
 .SH NAME
 ipa \- Ipa provides a Python API and command line...
 .SH SYNOPSIS

--- a/tests/data/.history
+++ b/tests/data/.history
@@ -1,2 +1,3 @@
 tests/data/not.log
 tests/data/history.log
+tests/data/history2.log

--- a/tests/data/history2.log
+++ b/tests/data/history2.log
@@ -1,0 +1,5 @@
+platform: ec2
+distro: SLES
+image: ami-859bd1e5
+instance: i-44444444444444444
+timestamp: 20170626142856

--- a/tests/data/history2.results
+++ b/tests/data/history2.results
@@ -1,0 +1,1 @@
+{"info": {"platform": "ec2", "image": "ami-859bd1e5", "instance": "i-44444444444444444", "timestamp": "20170626142857", "distro": "SLES"}, "tests": [], "summary": {"duration": 0, "passed": 0, "num_tests": 0}}

--- a/tests/test_ipa_cli.py
+++ b/tests/test_ipa_cli.py
@@ -142,7 +142,6 @@ def test_cli_archive():
 
         with open('tests/.history', 'w') as f:
             f.writelines([
-                'tests/data/not.log\n',
                 base_path + '20170626142856.log\n',
                 base_path + '20170626142857.log\n'
             ])
@@ -163,7 +162,7 @@ def test_cli_archive():
             main,
             [
                 'results', '--history-log', 'tests/.history', 'archive',
-                'archives/', '--clear-log'
+                '--clear-log', 'archives/', 'archive_123'
             ]
         )
         output = result.output.split(':')[-1].strip()
@@ -192,7 +191,6 @@ def test_cli_archive_item():
 
         with open('tests/.history', 'w') as f:
             f.writelines([
-                'tests/data/not.log\n',
                 base_path + '20170626142856.log\n',
                 base_path + '20170626142857.log\n'
             ])
@@ -207,9 +205,10 @@ def test_cli_archive_item():
             main,
             [
                 'results', '--history-log', 'tests/.history', 'archive',
-                'archives/', '--clear-log', '-i', '1'
+                '--clear-log', '-i', '2', 'archives/', 'archive_123'
             ]
         )
+
         output = result.output.split(':')[-1].strip()
         assert os.path.exists(output)
 
@@ -217,10 +216,36 @@ def test_cli_archive_item():
             main,
             ['results', '--history-log', 'tests/.history', 'list']
         )
-        expected_output = '2 tests/data/not.log\n' \
-            '1 tests/data/ec2/ami-859bd1e5/i-44444444444444444/' \
-            '20170626142856.log\n'
+        expected_output = '1 tests/data/ec2/ami-859bd1e5/' \
+            'i-44444444444444444/20170626142857.log\n'
         assert expected_output == result.output
+
+
+def test_cli_archive_missing_item():
+    """Test ipa archive missing history item."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        base_path = 'tests/data/ec2/ami-859bd1e5/i-44444444444444444/'
+        os.makedirs('archives')
+        os.makedirs('tests')
+
+        with open('tests/.history', 'w') as f:
+            f.writelines([
+                base_path + '20170626142856.log\n',
+            ])
+
+        result = runner.invoke(
+            main,
+            [
+                'results', '--history-log', 'tests/.history', 'archive',
+                '--clear-log', '-i', '1', 'archives/', 'archive_123'
+            ]
+        )
+
+        assert result.output == \
+            "Unable to archive history item: [Errno 2] No such file or " \
+            "directory: 'tests/data/ec2/ami-859bd1e5/i-44444444444444444/" \
+            "20170626142856.log'\n"
 
 
 def test_cli_results_log():

--- a/tests/test_ipa_cli.py
+++ b/tests/test_ipa_cli.py
@@ -120,6 +120,49 @@ def test_cli_results():
     assert result.exit_code == 0
 
 
+def test_cli_archive():
+    """Test ipa archive history sub command."""
+    with open('tests/data/history.log') as f:
+        log_file = f.readlines()
+
+    with open('tests/data/history.results') as f:
+        results_file = f.readlines()
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        base_path = 'tests/data/ec2/ami-859bd1e5/i-44444444444444444/'
+        os.makedirs(base_path)
+        os.makedirs('archives')
+
+        with open('tests/.history', 'w') as f:
+            f.writelines([
+                'tests/data/not.log\n',
+                base_path + '20170626142856.log\n'
+            ])
+
+        with open(base_path + '20170626142856.log', 'w') as f:
+            f.writelines(log_file)
+
+        with open(base_path + '20170626142856.results', 'w') as f:
+            f.writelines(results_file)
+
+        result = runner.invoke(
+            main,
+            [
+                'results', '--history-log', 'tests/.history', 'archive',
+                'archives/', '--clear-log'
+            ]
+        )
+        output = result.output.split(':')[-1].strip()
+        assert os.path.exists(output)
+
+        result = runner.invoke(
+            main,
+            ['results', '--history-log', 'tests/.history', 'list']
+        )
+        assert 'Path "tests/.history" does not exist.' in result.output
+
+
 def test_cli_results_log():
     """Test ipa results log display."""
     runner = CliRunner()


### PR DESCRIPTION
Allow for archiving of ipa results. All results and log files in addition to the history log will be copied to a tarball.

- Options `--clear-log` option will clear the history once the archive has complete.
- `--items` accepts a coma separated list of values to be archived. Using `--clear-log` in conjunction with `--items` will delete all items in the provided list from history file.

Fixes #1.