### PR TITLE
Allow new paths for history log option.

### DIFF
--- a/ipa/scripts/cli.py
+++ b/ipa/scripts/cli.py
@@ -118,7 +118,7 @@ def main(context, no_color):
 @click.option(
     '-h',
     '--history-log',
-    type=click.Path(exists=True),
+    type=click.Path(),
     help='ipa history log file location. Default: ~/.config/ipa/.history'
 )
 @click.option(


### PR DESCRIPTION
If the path does not exist IPA will attempt to create it.

Resolves #94 