### PR TITLE
openSUSE Leap requires auto import of repo keys.

### DIFF
--- a/ipa/ipa_opensuse_leap.py
+++ b/ipa/ipa_opensuse_leap.py
@@ -25,3 +25,7 @@ from ipa.ipa_sles import SLES
 
 class openSUSE_Leap(SLES):
     """openSUSE Leap distro class."""
+
+    def get_refresh_repo_cmd(self):
+        """Return refresh repo command for SLES."""
+        return 'zypper -n --gpg-auto-import-keys refresh'


### PR DESCRIPTION
When doing a refresh the Cloud:Tools and Python repos require import of new signing key.

Resolves #96 