### PR TITLE
Use the GCE service account in the launched instance.

### DIFF
--- a/ipa/ipa_gce.py
+++ b/ipa/ipa_gce.py
@@ -216,6 +216,10 @@ class GCEProvider(LibcloudProvider):
         kwargs = {
             'location': self.region,
             'ex_metadata': metadata,
+            'ex_service_accounts': [{
+                'email': self.service_account_email,
+                'scopes': ['storage-ro']
+            }]
         }
 
         if self.subnet_id:


### PR DESCRIPTION
Use the default scope provided by GCE with new instance: "read only storage".