### PR TITLE
Determine provider and region from instance

### DIFF
--- a/ipa/ipa_provider.py
+++ b/ipa/ipa_provider.py
@@ -281,12 +281,10 @@ class IpaProvider(object):
         if self.early_exit:
             options.append('-x')
 
-        args = '-v {} --ssh-config={} --hosts={} ' \
-            '--region="{}" {}'.format(
+        args = '-v {} --ssh-config={} --hosts={} {}'.format(
                 ' '.join(options),
                 ssh_config,
                 self.instance_ip,
-                self.results['info']['region'],
                 ' '.join(tests)
             )
 

--- a/ipa/ipa_provider.py
+++ b/ipa/ipa_provider.py
@@ -281,12 +281,11 @@ class IpaProvider(object):
         if self.early_exit:
             options.append('-x')
 
-        args = '-v {} --ssh-config={} --hosts={} --provider={} ' \
+        args = '-v {} --ssh-config={} --hosts={} ' \
             '--region="{}" {}'.format(
                 ' '.join(options),
                 ssh_config,
                 self.instance_ip,
-                self.results['info']['platform'].lower(),
                 self.results['info']['region'],
                 ' '.join(tests)
             )

--- a/usr/share/lib/ipa/tests/SLES/SAP/test_sles_sap_repos.py
+++ b/usr/share/lib/ipa/tests/SLES/SAP/test_sles_sap_repos.py
@@ -1,10 +1,10 @@
 
 
 def test_sles_sap_repos(check_zypper_repo,
+                        determine_provider,
                         get_release_value,
-                        get_sles_repos,
-                        request):
-    provider = request.config.getoption('provider')
+                        get_sles_repos):
+    provider = determine_provider()
     version = get_release_value('VERSION')
 
     for repo in get_sles_repos('%s-SAP' % version):

--- a/usr/share/lib/ipa/tests/SLES/infra/test_sles_force_new_smt_reg.py
+++ b/usr/share/lib/ipa/tests/SLES/infra/test_sles_force_new_smt_reg.py
@@ -5,12 +5,12 @@ from distutils.version import StrictVersion
 
 def test_sles_force_new_smt_reg(check_cloud_register,
                                 determine_provider,
+                                determine_region,
                                 get_smt_servers,
-                                host,
-                                request):
+                                host):
     certs_dir = '/var/lib/regionService/certs/'
     provider = determine_provider()
-    region = request.config.getoption('region')
+    region = determine_region(provider)
 
     result = host.run('zypper if cloud-regionsrv-client | grep Version')
     version = result.stdout.split(':')[-1].strip().split('-')[0]

--- a/usr/share/lib/ipa/tests/SLES/infra/test_sles_force_new_smt_reg.py
+++ b/usr/share/lib/ipa/tests/SLES/infra/test_sles_force_new_smt_reg.py
@@ -4,11 +4,12 @@ from distutils.version import StrictVersion
 
 
 def test_sles_force_new_smt_reg(check_cloud_register,
+                                determine_provider,
                                 get_smt_servers,
                                 host,
                                 request):
     certs_dir = '/var/lib/regionService/certs/'
-    provider = request.config.getoption('provider')
+    provider = determine_provider()
     region = request.config.getoption('region')
 
     result = host.run('zypper if cloud-regionsrv-client | grep Version')

--- a/usr/share/lib/ipa/tests/SLES/infra/test_sles_switch_smt.py
+++ b/usr/share/lib/ipa/tests/SLES/infra/test_sles_switch_smt.py
@@ -3,16 +3,16 @@ import shlex
 
 def test_sles_switch_smt(get_smt_server_name,
                          determine_provider,
+                         determine_region,
                          get_smt_servers,
-                         host,
-                         request):
+                         host):
     """
     This is a helper function for SMT failover test.
 
     It is cast as a test to be easily included in test suite.
     """
     provider = determine_provider()
-    region = request.config.getoption('region')
+    region = determine_region(provider)
 
     result = host.run(
         'cat /etc/hosts | grep %s' % get_smt_server_name(provider)

--- a/usr/share/lib/ipa/tests/SLES/infra/test_sles_switch_smt.py
+++ b/usr/share/lib/ipa/tests/SLES/infra/test_sles_switch_smt.py
@@ -2,6 +2,7 @@ import shlex
 
 
 def test_sles_switch_smt(get_smt_server_name,
+                         determine_provider,
                          get_smt_servers,
                          host,
                          request):
@@ -10,7 +11,7 @@ def test_sles_switch_smt(get_smt_server_name,
 
     It is cast as a test to be easily included in test suite.
     """
-    provider = request.config.getoption('provider')
+    provider = determine_provider()
     region = request.config.getoption('region')
 
     result = host.run(

--- a/usr/share/lib/ipa/tests/SLES/test_sles_repos.py
+++ b/usr/share/lib/ipa/tests/SLES/test_sles_repos.py
@@ -1,10 +1,10 @@
 
 
 def test_sles_repos(check_zypper_repo,
+                    determine_provider,
                     get_release_value,
-                    get_sles_repos,
-                    request):
-    provider = request.config.getoption('provider')
+                    get_sles_repos):
+    provider = determine_provider()
     version = get_release_value('VERSION')
 
     for repo in get_sles_repos(version):

--- a/usr/share/lib/ipa/tests/SLES/test_sles_smt_reg.py
+++ b/usr/share/lib/ipa/tests/SLES/test_sles_smt_reg.py
@@ -3,12 +3,12 @@ import shlex
 
 def test_sles_smt_reg(check_cloud_register,
                       determine_provider,
+                      determine_region,
                       get_smt_server_name,
                       get_smt_servers,
-                      host,
-                      request):
+                      host):
     provider = determine_provider()
-    region = request.config.getoption('region')
+    region = determine_region(provider)
 
     assert check_cloud_register()
 

--- a/usr/share/lib/ipa/tests/SLES/test_sles_smt_reg.py
+++ b/usr/share/lib/ipa/tests/SLES/test_sles_smt_reg.py
@@ -2,11 +2,12 @@ import shlex
 
 
 def test_sles_smt_reg(check_cloud_register,
+                      determine_provider,
                       get_smt_server_name,
                       get_smt_servers,
                       host,
                       request):
-    provider = request.config.getoption('provider')
+    provider = determine_provider()
     region = request.config.getoption('region')
 
     assert check_cloud_register()

--- a/usr/share/lib/ipa/tests/conftest.py
+++ b/usr/share/lib/ipa/tests/conftest.py
@@ -5,7 +5,6 @@ from susepubliccloudinfoclient import infoserverrequests
 
 
 def pytest_addoption(parser):
-    parser.addoption('--provider', action='store', help='ipa provider')
     parser.addoption('--region', action='store', help='ipa region')
 
 
@@ -36,6 +35,23 @@ def check_zypper_repo(host):
     def f(repo):
         repo = host.file('/etc/zypp/repos.d/' + repo + '.repo')
         return repo.exists
+    return f
+
+
+@pytest.fixture()
+def determine_provider(host):
+    def f():
+        result = host.run('sudo dmidecode -t system')
+        output = result.stdout.lower()
+        if 'amazon' in output:
+            provider = 'ec2'
+        elif 'microsoft' in output:
+            provider = 'azure'
+        elif 'google' in output:
+            provider = 'gce'
+        else:
+            raise Exception('Provider not found.')
+        return provider
     return f
 
 


### PR DESCRIPTION
Instead of injecting the values parse them from metadata and dmidecode output. This paves the way for testing instances as SSH only without the need for provider credentials.