### PR TITLE
 Remove deprecated ssh-private-key option.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+v2.0.0 (2018-08-15)
+===================
+
+- Remove deprecated --ssh-private-key option.
+  Option was renamed to --ssh-private-key-file.
+
 v1.4.0 (2018-08-15)
 ===================
 

--- a/ipa/__init__.py
+++ b/ipa/__init__.py
@@ -22,4 +22,4 @@
 
 __author__ = """SUSE"""
 __email__ = 'public-cloud-dev@susecloud.net'
-__version__ = '1.4.0'
+__version__ = '2.0.0'

--- a/ipa/scripts/cli.py
+++ b/ipa/scripts/cli.py
@@ -198,11 +198,6 @@ def main(context, no_color):
     help='Optional SSH private key-pair name for EC2.'
 )
 @click.option(
-    '--ssh-private-key',
-    type=click.Path(exists=True),
-    help='SSH private key file for accessing instance.'
-)
-@click.option(
     '--ssh-private-key-file',
     type=click.Path(exists=True),
     help='SSH private key file for accessing instance.'
@@ -262,7 +257,6 @@ def test(context,
          secret_access_key,
          service_account_file,
          ssh_key_name,
-         ssh_private_key,
          ssh_private_key_file,
          ssh_user,
          subnet_id,
@@ -275,15 +269,6 @@ def test(context,
     """Test image in the given framework using the supplied test files."""
     no_color = context.obj['no_color']
     try:
-        if ssh_private_key:
-            echo_style(
-                '--ssh-private-key option is deprecated and renamed to '
-                '--ssh-private-key-file. --ssh-private-key will be removed'
-                ' in a future release.',
-                no_color,
-                fg='red'
-            )
-
         status, results = test_image(
             provider,
             access_key_id,
@@ -307,7 +292,7 @@ def test(context,
             secret_access_key,
             service_account_file,
             ssh_key_name,
-            ssh_private_key_file or ssh_private_key,
+            ssh_private_key_file,
             ssh_user,
             subnet_id,
             test_dirs,

--- a/man/man1/ipa-list.1
+++ b/man/man1/ipa-list.1
@@ -1,4 +1,4 @@
-.TH "IPA LIST" "1" "09-Aug-2018" "" "ipa list Manual"
+.TH "IPA LIST" "1" "15-Aug-2018" "" "ipa list Manual"
 .SH NAME
 ipa\-list \- Print a list of test files or test cases.
 .SH SYNOPSIS

--- a/man/man1/ipa-results-archive.1
+++ b/man/man1/ipa-results-archive.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS ARCHIVE" "1" "09-Aug-2018" "" "ipa results archive Manual"
+.TH "IPA RESULTS ARCHIVE" "1" "15-Aug-2018" "" "ipa results archive Manual"
 .SH NAME
 ipa\-results\-archive \- Archive the history log and all results/log...
 .SH SYNOPSIS

--- a/man/man1/ipa-results-clear.1
+++ b/man/man1/ipa-results-clear.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS CLEAR" "1" "09-Aug-2018" "" "ipa results clear Manual"
+.TH "IPA RESULTS CLEAR" "1" "15-Aug-2018" "" "ipa results clear Manual"
 .SH NAME
 ipa\-results\-clear \- Clear the results from the history file.
 .SH SYNOPSIS

--- a/man/man1/ipa-results-delete.1
+++ b/man/man1/ipa-results-delete.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS DELETE" "1" "09-Aug-2018" "" "ipa results delete Manual"
+.TH "IPA RESULTS DELETE" "1" "15-Aug-2018" "" "ipa results delete Manual"
 .SH NAME
 ipa\-results\-delete \- Delete the specified history item from the...
 .SH SYNOPSIS

--- a/man/man1/ipa-results-list.1
+++ b/man/man1/ipa-results-list.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS LIST" "1" "09-Aug-2018" "" "ipa results list Manual"
+.TH "IPA RESULTS LIST" "1" "15-Aug-2018" "" "ipa results list Manual"
 .SH NAME
 ipa\-results\-list \- Display list of results history.
 .SH SYNOPSIS

--- a/man/man1/ipa-results-show.1
+++ b/man/man1/ipa-results-show.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS SHOW" "1" "09-Aug-2018" "" "ipa results show Manual"
+.TH "IPA RESULTS SHOW" "1" "15-Aug-2018" "" "ipa results show Manual"
 .SH NAME
 ipa\-results\-show \- Print test results info from provided results...
 .SH SYNOPSIS

--- a/man/man1/ipa-results.1
+++ b/man/man1/ipa-results.1
@@ -1,4 +1,4 @@
-.TH "IPA RESULTS" "1" "09-Aug-2018" "" "ipa results Manual"
+.TH "IPA RESULTS" "1" "15-Aug-2018" "" "ipa results Manual"
 .SH NAME
 ipa\-results \- Process provided history log and results...
 .SH SYNOPSIS

--- a/man/man1/ipa-test.1
+++ b/man/man1/ipa-test.1
@@ -1,4 +1,4 @@
-.TH "IPA TEST" "1" "09-Aug-2018" "" "ipa test Manual"
+.TH "IPA TEST" "1" "15-Aug-2018" "" "ipa test Manual"
 .SH NAME
 ipa\-test \- Test image in the given framework using the...
 .SH SYNOPSIS
@@ -77,7 +77,7 @@ GCE service account file for login credentials.
 \fB\-\-ssh\-key\-name\fP TEXT
 Optional SSH private key-pair name for EC2.
 .TP
-\fB\-\-ssh\-private\-key\fP PATH
+\fB\-\-ssh\-private\-key\-file\fP PATH
 SSH private key file for accessing instance.
 .TP
 \fB\-u,\fP \-\-ssh\-user TEXT

--- a/man/man1/ipa.1
+++ b/man/man1/ipa.1
@@ -1,4 +1,4 @@
-.TH "IPA" "1" "09-Aug-2018" "" "ipa Manual"
+.TH "IPA" "1" "15-Aug-2018" "" "ipa Manual"
 .SH NAME
 ipa \- Ipa provides a Python API and command line...
 .SH SYNOPSIS

--- a/package/python3-ipa.spec
+++ b/package/python3-ipa.spec
@@ -17,7 +17,7 @@
 
 %bcond_without test
 Name:           python3-ipa
-Version:        1.4.0
+Version:        2.0.0
 Release:        0
 Summary:        Command line and API for testing custom images
 License:        GPL-3.0+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.0
+current_version = 2.0.0
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ tox_requirements = [
 
 setup(
     name='python3-ipa',
-    version='1.4.0',
+    version='2.0.0',
     description="Package for automated testing of cloud images.",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Force major release with PR due to backward incompatible changes.