### PR TITLE
Update root pass test to work with SLE11.

### DIFF
--- a/usr/share/lib/ipa/tests/SLES/test_sles_root_pass.py
+++ b/usr/share/lib/ipa/tests/SLES/test_sles_root_pass.py
@@ -4,6 +4,6 @@ import shlex
 def test_sles_root_pass(host):
     # Ensure root does not have a password
     result = host.run(
-        'sudo passwd --status root'
+        'sudo passwd -S root'
     )
-    assert shlex.split(result.stdout.strip())[1] in ['L', 'NP']
+    assert shlex.split(result.stdout.strip())[1] in ['L', 'LK', 'NP']


### PR DESCRIPTION
- --status option is not available thus use the shortcode -S.
- Add locked status to valid values (LK).