### PR TITLE
Account for sysvinit in SLE11.

### DIFF
--- a/usr/share/lib/ipa/tests/SLES/EC2/test_sles_ec2_services.py
+++ b/usr/share/lib/ipa/tests/SLES/EC2/test_sles_ec2_services.py
@@ -2,10 +2,10 @@ import pytest
 
 
 @pytest.mark.parametrize('name', [
-    ('cloud-init-local.service'),
-    ('cloud-init.service'),
-    ('cloud-config.service'),
-    ('cloud-final.service')
+    ('cloud-init-local'),
+    ('cloud-init'),
+    ('cloud-config'),
+    ('cloud-final')
 ])
 def test_sles_ec2_services(check_service, name):
     assert check_service(name)

--- a/usr/share/lib/ipa/tests/SLES/GCE/test_sles_gce_services.py
+++ b/usr/share/lib/ipa/tests/SLES/GCE/test_sles_gce_services.py
@@ -2,25 +2,25 @@ import pytest
 
 
 @pytest.mark.parametrize('name', [
-    'google-accounts-daemon.service',
-    'google-clock-skew-daemon.service',
-    'google-network-daemon.service',
-    'google-shutdown-scripts.service'
+    'google-accounts-daemon',
+    'google-clock-skew-daemon',
+    'google-network-daemon'
 ])
 def test_sles_gce_running_services(check_service, name):
     assert check_service(name)
 
 
 @pytest.mark.parametrize('name', [
-    'google-instance-setup.service',
-    'google-startup-scripts.service',
-    'google-shutdown-scripts.service'  # Exits but remains active
+    'google-instance-setup',
+    'google-startup-scripts',
+    'google-shutdown-scripts'
 ])
-def test_sles_gce_one_shot_services(host, name):
-    service = host.service(name)
-    assert service.is_enabled
+def test_sles_gce_one_shot_services(check_service, host, name):
+    assert check_service(name, running=None)
 
-    output = host.run(
-        "systemctl show -p Result {0} | sed 's/Result=//g'".format(name)
-    )
-    assert output.stdout.strip() == 'success'
+    if host.exists('systemctl'):
+        # No clear way to check a service exited successfully using sysvinit
+        output = host.run(
+            "systemctl show -p Result {0} | sed 's/Result=//g'".format(name)
+        )
+        assert output.stdout.strip() == 'success'

--- a/usr/share/lib/ipa/tests/SLES/test_sles_guestregister.py
+++ b/usr/share/lib/ipa/tests/SLES/test_sles_guestregister.py
@@ -1,2 +1,2 @@
 def test_sles_guestregister(check_service):
-    assert check_service('guestregister.service', running=False)
+    assert check_service('guestregister', running=False)

--- a/usr/share/lib/ipa/tests/SLES/test_sles_haveged.py
+++ b/usr/share/lib/ipa/tests/SLES/test_sles_haveged.py
@@ -1,2 +1,2 @@
 def test_sles_haveged(check_service):
-    assert check_service('haveged.service')
+    assert check_service('haveged')


### PR DESCRIPTION
- Testinfra has bugs that fail for SUSE.
  - Fix the location of rc?.d dirs.
  - Fix service command to run as root via sudo.
- Remove .service from names to handle SysV names.
  - testinfra automagically adds .service to name if necessary for systemctl.
- Update check_service to allow None for args. This always passes. I.e. if you only want to check if a service is enabled and it can be running or stopped.