### PR TITLE
Add python3.7 to CI testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ branches:
   only:
     - master
     - /\bv[0-9]/
+dist: xenial
 python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 install:
   - pip install -e .[dev]
 script:


### PR DESCRIPTION
3.7 requires xenial distribution.