### PR TITLE
Add --name option to az creds example.

### DIFF
--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -152,7 +152,7 @@ The following command will generate the necessary json file:
 
 .. code-block:: console
     
-   $ az ad sp create-for-rbac --sdk-auth > mycredentials.json
+   $ az ad sp create-for-rbac --sdk-auth --name "{name}" > mycredentials.json
 
 See `Azure docs`_ for more info on creating a service principal json file.
 


### PR DESCRIPTION
If a name is not set the name is autogenerated and not easy to find in web console.