### PR TITLE
With running instance don't cleanup.

### DIFF
--- a/ipa/ipa_provider.py
+++ b/ipa/ipa_provider.py
@@ -629,6 +629,11 @@ class IpaProvider(object):
             # Use existing instance
             self._start_instance_if_stopped()
             self._set_image_id()
+
+            # With a running instance default to no cleanup
+            # if a value has not been provided.
+            if self.cleanup is None:
+                self.cleanup = False
         else:
             # Launch new instance
             self.logger.info('Launching new instance')

--- a/tests/test_ipa_provider.py
+++ b/tests/test_ipa_provider.py
@@ -537,6 +537,7 @@ class TestIpaProvider(object):
         mock_set_instance_ip.return_value = None
         self.kwargs['running_instance_id'] = 'fakeinstance'
         self.kwargs['test_files'] = ['test_update']
+        self.kwargs['cleanup'] = True
 
         provider = IpaProvider(*args, **self.kwargs)
         provider.ssh_private_key_file = 'tests/data/ida_test'
@@ -545,6 +546,7 @@ class TestIpaProvider(object):
         status, results = provider.test_image()
         assert status == 0
         assert mock_distro_update.call_count == 1
+        self.kwargs['cleanup'] = None
 
     @patch.object(IpaProvider, '_set_instance_ip')
     @patch.object(IpaProvider, '_set_image_id')


### PR DESCRIPTION
By default if cleanup value is not provided do not cleanup running instance.