### PR TITLE
Process pytest errors in results.

### DIFF
--- a/ipa/ipa_provider.py
+++ b/ipa/ipa_provider.py
@@ -299,7 +299,7 @@ class IpaProvider(object):
             self.test_files
         )
 
-    def _process_sync_test_results(self, duration, test_name, success=0):
+    def _process_test_results(self, duration, test_name, success=0):
         """Create result dict for sync test and merge with overall results."""
         status = 'passed' if success == 0 else 'failed'
         result = {
@@ -342,7 +342,14 @@ class IpaProvider(object):
         cmds = shlex.split(args)
         plugin = Report()
         result = pytest.main(cmds, plugins=[plugin])
-        self._merge_results(plugin.report)
+
+        # If pytest has an error there will be no report but
+        # we still want to process the error as a failure.
+        # https://docs.pytest.org/en/latest/usage.html#possible-exit-codes
+        if result in (2, 3, 4):
+            self._process_test_results(0, 'pytest_error', 1)
+        else:
+            self._merge_results(plugin.report)
 
         return result
 
@@ -693,7 +700,7 @@ class IpaProvider(object):
                         break
                     finally:
                         duration = time.time() - start
-                        self._process_sync_test_results(
+                        self._process_test_results(
                             duration, 'test_hard_reboot', result
                         )
                         status = status or result
@@ -725,7 +732,7 @@ class IpaProvider(object):
                         break
                     finally:
                         duration = time.time() - start
-                        self._process_sync_test_results(
+                        self._process_test_results(
                             duration, 'test_soft_reboot', result
                         )
                         status = status or result
@@ -746,7 +753,7 @@ class IpaProvider(object):
                             log_file.write(out)
                     finally:
                         duration = time.time() - start
-                        self._process_sync_test_results(
+                        self._process_test_results(
                             duration, 'test_update', result
                         )
                         status = status or result

--- a/tests/test_ipa_provider.py
+++ b/tests/test_ipa_provider.py
@@ -188,9 +188,9 @@ class TestIpaProvider(object):
         for key, val in results['tests'][0].items():
             assert provider.results['tests'][0][key] == val
 
-    def test_process_sync_test_results(self):
+    def test_process_test_results(self):
         provider = IpaProvider(*args, **self.kwargs)
-        provider._process_sync_test_results(5.0, 'test_test')
+        provider._process_test_results(5.0, 'test_test')
 
         assert provider.results['summary']['duration'] == 5.0
         assert provider.results['summary']['num_tests'] == 1


### PR DESCRIPTION
If pytest returns a status code of 2-4 an error occurred. There will be no report provided so instead add a generic error test with failed state. This prevents IPA from also crashing and not finishing gracefully.