### PR TITLE
Allow azure instance to start in existing subnet.

### DIFF
--- a/tests/test_ipa_azure.py
+++ b/tests/test_ipa_azure.py
@@ -203,8 +203,6 @@ class TestAzureProvider(object):
 
         assert provider.ip_config_name == 'fakeinstance-ip-config'
         assert provider.nic_name == 'fakeinstance-nic'
-        assert provider.subnet_name == 'fakeinstance-subnet'
-        assert provider.vnet_name == 'fakeinstance-vnet'
         assert provider.public_ip_name == 'fakeinstance-public-ip'
 
     @patch.object(AzureProvider, '_get_instance')


### PR DESCRIPTION
Cleanup naming for subnet_id in azure class. And make exception condition more robust. Fail if any subnet arg is provided and not all are provided.

Fixes #157 