### PR TITLE
Allow use of ipa config for provider options.

### DIFF
--- a/ipa/ipa_azure.py
+++ b/ipa/ipa_azure.py
@@ -93,15 +93,23 @@ class AzureProvider(IpaProvider):
                                             ssh_private_key_file,
                                             ssh_user)
 
-        subnet_args = [subnet_id, vnet_name, vnet_resource_group]
+        self.subnet_id = subnet_id or self.ipa_config['subnet_id']
+        self.vnet_name = vnet_name or self.ipa_config['vnet_name']
+        self.vnet_resource_group = (
+                vnet_resource_group or self.ipa_config['vnet_resource_group']
+        )
+
+        subnet_args = [
+            self.subnet_id, self.vnet_name, self.vnet_resource_group
+        ]
         if any(subnet_args) and not all(subnet_args):
             raise AzureProviderException(
                 'subnet_id, vnet_resource_group and vnet_name'
                 ' are all required to use an existing subnet.'
             )
 
-        self.service_account_file = self._get_value(
-            service_account_file, 'service_account_file'
+        self.service_account_file = (
+            service_account_file or self.ipa_config['service_account_file']
         )
         if not self.service_account_file:
             raise AzureProviderException(
@@ -117,12 +125,12 @@ class AzureProvider(IpaProvider):
                 'SSH private key file is required to connect to instance.'
             )
 
-        self.accelerated_networking = accelerated_networking
+        self.accelerated_networking = (
+            accelerated_networking or
+            self.ipa_config['accelerated_networking']
+        )
         self.ssh_user = self.ssh_user or AZURE_DEFAULT_USER
         self.ssh_public_key = self._get_ssh_public_key()
-        self.subnet_id = subnet_id
-        self.vnet_resource_group = vnet_resource_group
-        self.vnet_name = vnet_name
 
         self.compute = self._get_management_client(ComputeManagementClient)
         self.network = self._get_management_client(NetworkManagementClient)

--- a/ipa/ipa_gce.py
+++ b/ipa/ipa_gce.py
@@ -94,8 +94,8 @@ class GCEProvider(LibcloudProvider):
                                           collect_vm_info,
                                           ssh_private_key_file,
                                           ssh_user)
-        self.service_account_file = self._get_value(
-            service_account_file, 'service_account_file'
+        self.service_account_file = (
+            service_account_file or self.ipa_config['service_account_file']
         )
         if not self.service_account_file:
             raise GCEProviderException(
@@ -113,7 +113,7 @@ class GCEProvider(LibcloudProvider):
 
         self.ssh_user = self.ssh_user or GCE_DEFAULT_USER
         self.ssh_public_key = self._get_ssh_public_key()
-        self.subnet_id = subnet_id
+        self.subnet_id = subnet_id or self.ipa_config['subnet_id']
 
         self._get_service_account_info()
         self.compute_driver = self._get_driver()

--- a/tests/test_ipa_provider.py
+++ b/tests/test_ipa_provider.py
@@ -125,14 +125,16 @@ class TestIpaProvider(object):
 
         ipa_utils.clear_cache()
 
-    def test_provider_get_value(self):
-        """Test provider get value method."""
+    def test_provider_get_non_null_values(self):
+        """Test provider get non null values method."""
         provider = IpaProvider(*args, **self.kwargs)
+
+        data = {'region': 'us-east-1', 'type': None}
+
         # Assert arg takes precedence
-        val = provider._get_value(
-            'us-east-1', 'region'
-        )
-        assert val == 'us-east-1'
+        val = provider._get_non_null_values(data)
+        assert 'type' not in val
+        assert val['region'] == 'us-east-1'
 
     def test_provider_merge_results(self):
         """Test merge results output."""


### PR DESCRIPTION
ChainMap the command line values as well and remove need for an additional get_value method.

Use ChainMap for handling ec2 config similar to ipa config.