### PR TITLE
Check for ssh key file separately in ec2.

### DIFF
--- a/ipa/ipa_ec2.py
+++ b/ipa/ipa_ec2.py
@@ -136,9 +136,14 @@ class EC2Cloud(IpaCloud):
         self.secret_access_key = self.ec2_config['secret_access_key']
         self.security_group_id = self.ec2_config['security_group_id']
         self.ssh_key_name = self.ec2_config['ssh_key_name']
-        self.ssh_private_key_file = self.ec2_config['ssh_private_key']
         self.ssh_user = self.ec2_config['ssh_user'] or EC2_DEFAULT_USER
         self.subnet_id = self.ec2_config['subnet_id']
+
+        self.ssh_private_key_file = (
+            cmd_line_values.get('ssh_private_key_file') or
+            ec2_config.get('ssh_private_key') or
+            self.ipa_config.get('ssh_private_key_file')
+        )
 
         if not self.ssh_private_key_file:
             raise EC2CloudException(


### PR DESCRIPTION
The ec2utils config has a different key name (ssh_private_key vs ssh_private_key_file).

Fixes #168 