### PR TITLE
Use pytest fail instead of raise exception.

### DIFF
--- a/usr/share/lib/ipa/tests/SLES/EC2/test_sles_ec2_network.py
+++ b/usr/share/lib/ipa/tests/SLES/EC2/test_sles_ec2_network.py
@@ -59,4 +59,4 @@ def test_sles_ec2_network(determine_region, host):
 
     size = dl_result.stdout.strip()
     if size != '1214599168':
-        raise Exception('Download failed!')
+        pytest.fail('Download failed!')

--- a/usr/share/lib/ipa/tests/SLES/conftest.py
+++ b/usr/share/lib/ipa/tests/SLES/conftest.py
@@ -324,7 +324,7 @@ SLES_REPOS = {
 @pytest.fixture()
 def get_sles_repos():
     def f(version):
-        return SLES_REPOS[version]
+        return SLES_REPOS.get(version)
     return f
 
 

--- a/usr/share/lib/ipa/tests/SLES/test_sles_repos.py
+++ b/usr/share/lib/ipa/tests/SLES/test_sles_repos.py
@@ -1,3 +1,4 @@
+import pytest
 
 
 def test_sles_repos(check_zypper_repo,
@@ -13,7 +14,14 @@ def test_sles_repos(check_zypper_repo,
         version += '-SAP'
 
     missing_repos = []
-    for repo in get_sles_repos(version):
+    repos = get_sles_repos(version)
+
+    if not repos:
+        pytest.fail(
+            'No repos found for version {0}'.format(version)
+        )
+
+    for repo in repos:
         result = check_zypper_repo(
             ''.join([
                 'SMT-http_smt-{provider}_susecloud_net:'.format(
@@ -33,6 +41,6 @@ def test_sles_repos(check_zypper_repo,
             )
 
     if missing_repos:
-        raise Exception(
+        pytest.fail(
             'Missing Repos: \n{0}'.format('\n'.join(missing_repos))
         )

--- a/usr/share/lib/ipa/tests/SLES/test_sles_wait_on_registration.py
+++ b/usr/share/lib/ipa/tests/SLES/test_sles_wait_on_registration.py
@@ -1,3 +1,4 @@
+import pytest
 import time
 
 
@@ -13,6 +14,6 @@ def test_sles_wait_on_registration(host):
         else:
             time.sleep(10)
     else:
-        raise Exception(
+        pytest.fail(
             'Registration did not finish properly for on-demand instance.'
         )


### PR DESCRIPTION
Return None if no repos found and fail with a useful exception
instead of failing with keyerror.