### PR TITLE
- Allow update test with file conflicts to pass

### DIFF
--- a/ipa/ipa_sles.py
+++ b/ipa/ipa_sles.py
@@ -53,3 +53,16 @@ class SLES(Distro):
     def get_update_cmd(self):
         """Return command to update SLES instance."""
         return 'zypper -n up --auto-agree-with-licenses --force-resolution'
+
+    def update(self, client):
+        """Handle distinct zypper error codes and allow them as pass
+           8 - File conflicts"""
+
+        zypper_msg = super().update(client)
+        if (
+                zypper_msg and
+                'File conflicts happen when ' in zypper_msg
+        ):
+            zypper_msg = ''
+
+        return zypper_msg

--- a/tests/test_ipa_sles_distro.py
+++ b/tests/test_ipa_sles_distro.py
@@ -132,3 +132,41 @@ def test_sles_update_exception():
         "sudo sh -c 'zypper -n refresh;zypper -n up "
         "--auto-agree-with-licenses --force-resolution'"
     )
+
+
+def test_sles_update_file_conflict():
+    """Test update method when update has file conflicts."""
+    client = MagicMock()
+    sles = SLES()
+
+    file_conf_msg = (
+        'error\nDetected 3 file conflicts:\n\nFile '
+        '/etc/issue\n  from install of\n     '
+        'SLES_SAP-release-12.1-2.1.x86_64 (SLE-12-SP1-SAP-Updates)\r\n  '
+        'conflicts with file from package\n     '
+        'sles-release-12.1-1.331.x86_64 (@System)\n\nFile /etc/issue.net'
+        '\n  from install of\n     SLES_SAP-release-12.1-2.1.x86_64 '
+        '(SLE-12-SP1-SAP-Updates)\n  conflicts with file from package'
+        '\n     sles-release-12.1-1.331.x86_64 (@System)\n\nFile /etc/'
+        'os-release\n  from install of\n     '
+        'SLES_SAP-release-12.1-2.1.x86_64 (SLE-12-SP1-SAP-Updates)\n  '
+        'conflicts with file from package\n     '
+        'sles-release-12.1-1.331.x86_64 (@System)\n\nFile conflicts '
+        'happen when two packages attempt to install '
+        'files with the same name but different contents. If you continue, '
+        'conflicting files will be replaced losing the previous content.\n'
+        'Continue? [yes/no] (no): \n\n'
+        'Problem occured during or after installation or '
+        'removal of packages:\nInstallation aborted by user\n\n'
+        'Please see the above error message for a hint.\n'
+    )
+    with patch('ipa.ipa_utils.execute_ssh_command', MagicMock(
+            return_value=file_conf_msg)) as mocked:
+        output = sles.update(client)
+
+    mocked.assert_called_once_with(
+        client,
+        "sudo sh -c 'zypper -n refresh;zypper -n up "
+        "--auto-agree-with-licenses --force-resolution'"
+    )
+    assert output == ''


### PR DESCRIPTION
  + When an update has file conflicts at present we error out. However,
    our intention of th etest is to make sure we can get updates from the
    update server. We do not care to test for packaging bugs.