### PR TITLE
Add replacefiles option to zypper update.

### DIFF
--- a/ipa/ipa_sles.py
+++ b/ipa/ipa_sles.py
@@ -52,4 +52,5 @@ class SLES(Distro):
 
     def get_update_cmd(self):
         """Return command to update SLES instance."""
-        return 'zypper -n up --auto-agree-with-licenses --force-resolution'
+        return 'zypper -n up --auto-agree-with-licenses ' \
+               '--force-resolution --replacefiles'

--- a/ipa/ipa_utils.py
+++ b/ipa/ipa_utils.py
@@ -106,9 +106,9 @@ def execute_ssh_command(client, cmd):
     try:
         stdin, stdout, stderr = client.exec_command(cmd)
         err = stderr.read()
-        if err:
-            raise IpaSSHException(err.decode())
         out = stdout.read()
+        if err:
+            raise IpaSSHException(out.decode() + err.decode())
     except:  # noqa: E722
         raise
     return out.decode()

--- a/tests/test_ipa_sles_distro.py
+++ b/tests/test_ipa_sles_distro.py
@@ -109,7 +109,7 @@ def test_sles_update():
     mocked.assert_called_once_with(
         client,
         "sudo sh -c 'zypper -n refresh;zypper -n up "
-        "--auto-agree-with-licenses --force-resolution'"
+        "--auto-agree-with-licenses --force-resolution --replacefiles'"
     )
     assert output == 'Update finished!'
 
@@ -130,5 +130,5 @@ def test_sles_update_exception():
     mocked.assert_called_once_with(
         client,
         "sudo sh -c 'zypper -n refresh;zypper -n up "
-        "--auto-agree-with-licenses --force-resolution'"
+        "--auto-agree-with-licenses --force-resolution --replacefiles'"
     )

--- a/tests/test_ipa_utils.py
+++ b/tests/test_ipa_utils.py
@@ -117,10 +117,13 @@ def test_utils_ssh_exec_command():
 
 def test_utils_ssh_exec_command_exception():
     """Test error in ssh exec command raises exception."""
-    stdin = stdout = MagicMock()
+    stdin = MagicMock()
 
     stderr = MagicMock()
     stderr.read.return_value = b'Exception: ls is not allowed!'
+
+    stdout = MagicMock()
+    stdout.read.return_value = b'Other information\n'
 
     client = MagicMock()
     client.exec_command.return_value = (stdin, stdout, stderr)
@@ -128,7 +131,8 @@ def test_utils_ssh_exec_command_exception():
     with pytest.raises(IpaSSHException) as error:
         ipa_utils.execute_ssh_command(client, 'ls')
 
-    assert str(error.value) == 'Exception: ls is not allowed!'
+    msg = 'Other information\nException: ls is not allowed!'
+    assert str(error.value) == msg
 
 
 def test_utils_expand_test_files():


### PR DESCRIPTION
Append out to err message when an ssh command fails.

Supercedes #179 Fixes #180