### PR TITLE
Use format string for motd check.

### DIFF
--- a/usr/share/lib/ipa/tests/SLES/test_sles_motd.py
+++ b/usr/share/lib/ipa/tests/SLES/test_sles_motd.py
@@ -1,5 +1,9 @@
 def test_sles_motd(host, get_release_value):
     motd = host.file('/etc/motd')
-    pretty_name = get_release_value('PRETTY_NAME')
-    assert pretty_name
-    assert motd.contains(pretty_name)
+    version = get_release_value('VERSION')
+    assert version
+    assert motd.contains(
+        'SUSE Linux Enterprise Server {0}'.format(
+            version.replace('-', ' ')
+        )
+    )


### PR DESCRIPTION
The pretty name in os-release is not always consistent.