### PR TITLE
EC2 instances may have ipv6_addresses set to None.

### DIFF
--- a/ipa/ipa_ec2.py
+++ b/ipa/ipa_ec2.py
@@ -300,7 +300,7 @@ class EC2Cloud(IpaCloud):
         # ipv6
         try:
             ipv6 = instance.network_interfaces[0].ipv6_addresses[0]
-        except IndexError:
+        except (IndexError, TypeError):
             ipv6 = None
 
         self.instance_ip = instance.public_ip_address or \


### PR DESCRIPTION
ipv6_addresses may be None type in China regions instead of empty iterable.

Handle TypeError in except in case the object is None instead of an iterable.