### PR TITLE
Cast timeout to integer.

### DIFF
--- a/ipa/ipa_azure.py
+++ b/ipa/ipa_azure.py
@@ -421,6 +421,7 @@ class AzureCloud(IpaCloud):
         self.running_instance_id = ipa_utils.generate_instance_name(
             'azure-ipa-test'
         )
+        self.logger.debug('ID of instance: %s' % self.running_instance_id)
         self._set_default_resource_names()
 
         try:

--- a/ipa/ipa_cloud.py
+++ b/ipa/ipa_cloud.py
@@ -140,7 +140,7 @@ class IpaCloud(object):
         self.inject = self.ipa_config['inject']
         self.instance_type = self.ipa_config['instance_type']
         self.test_files = list(self.ipa_config['test_files'])
-        self.timeout = self.ipa_config['timeout']
+        self.timeout = int(self.ipa_config['timeout'])
         self.history_log = self.ipa_config['history_log']
         self.region = self.ipa_config['region']
         self.collect_vm_info = self.ipa_config['collect_vm_info']
@@ -623,7 +623,6 @@ class IpaCloud(object):
             # Launch new instance
             self.logger.info('Launching new instance')
             self._launch_instance()
-            self.logger.debug('ID of instance: %s' % self.running_instance_id)
 
         if not self.instance_ip:
             self._set_instance_ip()

--- a/ipa/ipa_ec2.py
+++ b/ipa/ipa_ec2.py
@@ -282,6 +282,7 @@ class EC2Cloud(IpaCloud):
             )
 
         self.running_instance_id = instances[0].instance_id
+        self.logger.debug('ID of instance: %s' % self.running_instance_id)
         self._wait_on_instance('running', self.timeout)
 
     def _set_image_id(self):

--- a/ipa/ipa_gce.py
+++ b/ipa/ipa_gce.py
@@ -195,6 +195,7 @@ class GCEProvider(LibcloudCloud):
         self.running_instance_id = ipa_utils.generate_instance_name(
             'gce-ipa-test'
         )
+        self.logger.debug('ID of instance: %s' % self.running_instance_id)
 
         kwargs = {
             'location': self.region,


### PR DESCRIPTION
- Timeout will always have a default so no issue with casting None.
- Print instance id as soon as possible in case of error.