### PR TITLE
Fix Azure service test on SLES 11

### DIFF
--- a/usr/share/lib/ipa/tests/SLES/Azure/test_sles_azure_services.py
+++ b/usr/share/lib/ipa/tests/SLES/Azure/test_sles_azure_services.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.mark.parametrize('name', [
-    ('waagent.service'),
+    ('waagent'),
 ])
 def test_sles_azure_services(check_service, name):
     assert check_service(name)


### PR DESCRIPTION
Sysvinit doesn't like the "*.service" extension used with systemctl.