### PR TITLE
Check default dirs exist in ipa list.

### DIFF
--- a/ipa/ipa_controller.py
+++ b/ipa/ipa_controller.py
@@ -21,6 +21,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
+import os
 import pytest
 import shlex
 
@@ -138,10 +139,17 @@ def collect_results(results_file):
     return data
 
 
-def collect_tests(test_dirs, verbose=False):
+def collect_tests(test_dirs=TEST_PATHS, verbose=False):
     """Return a list of test files and/or tests cases."""
+    if test_dirs:
+        test_dirs = [
+            test_dir for test_dir in test_dirs if os.path.exists(test_dir)
+        ]
+
     if not test_dirs:
-        test_dirs = TEST_PATHS
+        raise IpaControllerException(
+            'No test directories found.'
+        )
 
     if verbose:
         plugin = CollectItemsPlugin()

--- a/ipa/scripts/cli.py
+++ b/ipa/scripts/cli.py
@@ -34,6 +34,7 @@ from ipa.ipa_constants import (
     SUPPORTED_CLOUDS
 )
 from ipa import ipa_utils
+from ipa.ipa_constants import TEST_PATHS
 from ipa.ipa_controller import collect_tests, test_image
 from ipa.scripts.cli_utils import (
     archive_history_item,
@@ -605,6 +606,8 @@ def list_tests(context, verbose, test_dirs):
     tests otherwise the default test directories are used.
     """
     no_color = context.obj['no_color']
+    test_dirs = test_dirs or TEST_PATHS
+
     try:
         results = collect_tests(test_dirs, verbose)
     except Exception as error:

--- a/tests/test_ipa_controller.py
+++ b/tests/test_ipa_controller.py
@@ -1,0 +1,37 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+"""IPA controller unit tests."""
+
+# Copyright (c) 2019 SUSE LLC. All rights reserved.
+#
+# This file is part of ipa. Ipa provides an api and command line
+# utilities for testing images in the Public Cloud.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pytest import raises
+from unittest.mock import patch
+
+from ipa.ipa_controller import collect_tests
+from ipa.ipa_exceptions import IpaControllerException
+
+
+@patch('ipa.ipa_controller.os')
+def test_collect_tests_no_dirs(mock_os):
+    """Test collect tests default directories do not exist."""
+    mock_os.path.exists.return_value = False
+
+    with raises(IpaControllerException):
+        collect_tests(verbose=True)


### PR DESCRIPTION
If a directory that does not exist is passed into pytest collect an exception is raised. Drop any directories from search that do not exist. Include regression test for default directories all not existing.

Fixes #190 