### PR TITLE
Clear ssh cache at start of module.

### DIFF
--- a/ipa/ipa_cloud.py
+++ b/ipa/ipa_cloud.py
@@ -99,6 +99,8 @@ class IpaCloud(object):
         # Get command line values that are not None
         cmd_line_values = self._get_non_null_values(locals())
 
+        ipa_utils.clear_cache()
+
         self.cloud = cloud
         self.host_key_fingerprint = None
         self.instance_ip = None

--- a/ipa/ipa_utils.py
+++ b/ipa/ipa_utils.py
@@ -275,8 +275,13 @@ def get_ssh_client(ip,
                    timeout=600,
                    wait_period=10):
     """Attempt to establish and test ssh connection."""
-    if ip in CLIENT_CACHE:
-        return CLIENT_CACHE[ip]
+    if CLIENT_CACHE.get(ip):
+        try:
+            execute_ssh_command(CLIENT_CACHE[ip], 'ls')
+        except Exception:
+            clear_cache(ip)
+        else:
+            return CLIENT_CACHE[ip]
 
     start = time.time()
     end = start + timeout

--- a/tests/test_ipa_utils.py
+++ b/tests/test_ipa_utils.py
@@ -38,7 +38,8 @@ from unittest.mock import MagicMock, patch
 LOCALHOST = '127.0.0.1'
 
 
-def test_utils_clear_cache():
+@patch('ipa.ipa_utils.execute_ssh_command')
+def test_utils_clear_cache(mock_exec_cmd):
     """Test ipa utils client cache and clear specific ip."""
     client = MagicMock()
     ipa_utils.CLIENT_CACHE[LOCALHOST] = client


### PR DESCRIPTION
Test cached connections prior to returning. If command fails clear connection from cache and get new connection.

This possibly Fixes #195 however the `paramiko.ssh_exception.SSHException: No existing session` exception can happen for many reasons.