### PR TITLE
Echo log file if results file provided.

### DIFF
--- a/ipa/scripts/cli.py
+++ b/ipa/scripts/cli.py
@@ -577,7 +577,8 @@ def show(context,
 
     elif log:
         # Log file provided
-        echo_log(results_file, no_color)
+        log_file = results_file.rsplit('.', 1)[0] + '.log'
+        echo_log(log_file, no_color)
     else:
         # Results file provided
         echo_results_file(results_file, no_color, verbose)


### PR DESCRIPTION
Swap extension for .log if the results_file path is provided. This echos the contents of the log file to terminal for review.

Fixes #194 